### PR TITLE
[feat] 관리자 페이지 구현

### DIFF
--- a/src/components/skeletons/CreateChallengeSkeleton.vue
+++ b/src/components/skeletons/CreateChallengeSkeleton.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+defineProps<{
+  padding?: 'normal' | 'large'
+}>()
+</script>
+
+<template>
+  <div class="animate-pulse">
+    <div
+      class="rounded-lg bg-white shadow-sm"
+      :class="{
+        'p-4': padding === 'normal' || !padding,
+        'p-6': padding === 'large',
+      }"
+    >
+      <div class="space-y-6">
+        <!-- 챌린지 유형 -->
+        <div class="space-y-2">
+          <div class="h-4 w-24 rounded bg-gray-200"></div>
+          <div class="flex gap-4">
+            <div class="h-6 w-32 rounded bg-gray-200"></div>
+            <div class="h-6 w-32 rounded bg-gray-200"></div>
+          </div>
+        </div>
+
+        <!-- 카테고리 -->
+        <div class="space-y-2">
+          <div class="h-4 w-20 rounded bg-gray-200"></div>
+          <div class="h-10 w-full rounded bg-gray-200"></div>
+        </div>
+
+        <!-- 챌린지 제목 -->
+        <div class="space-y-2">
+          <div class="h-4 w-24 rounded bg-gray-200"></div>
+          <div class="h-10 w-full rounded bg-gray-200"></div>
+        </div>
+
+        <!-- 챌린지 설명 -->
+        <div class="space-y-2">
+          <div class="h-4 w-24 rounded bg-gray-200"></div>
+          <div class="h-24 w-full rounded bg-gray-200"></div>
+        </div>
+
+        <!-- 목표 인원 수 -->
+        <div class="space-y-2">
+          <div class="h-4 w-28 rounded bg-gray-200"></div>
+          <div class="h-10 w-full rounded bg-gray-200"></div>
+        </div>
+
+        <!-- 날짜 필드들 -->
+        <div class="space-y-2">
+          <div class="h-4 w-24 rounded bg-gray-200"></div>
+          <div class="h-10 w-full rounded bg-gray-200"></div>
+        </div>
+
+        <div class="space-y-2">
+          <div class="h-4 w-24 rounded bg-gray-200"></div>
+          <div class="h-10 w-full rounded bg-gray-200"></div>
+        </div>
+
+        <!-- 버튼 -->
+        <div class="flex justify-end">
+          <div class="h-10 w-32 rounded bg-gray-200"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/core/challenge/AdminChallengeApi.ts
+++ b/src/core/challenge/AdminChallengeApi.ts
@@ -5,6 +5,16 @@ import { getToken } from "../auth/services/loginService"
 
 const { VITE_API_URL } = import.meta.env
 
+export const addChallengeFetch = async (challenge: Challenge): Promise<AxiosResponse<ApiResponse>> => {
+  const response = await axios.post(`${VITE_API_URL}/admin/challenge`, challenge, {
+    headers: {
+      Authorization: getToken()
+    }
+  })
+  console.log('API Response:', response)  // 응답 데이터 로깅
+  return response
+}
+
 export const addChallengeScheduleFetch = async (challenge: Challenge): Promise<AxiosResponse<ApiResponse>> => {
   const response = await axios.post(`${VITE_API_URL}/admin/challenge/schedule`, challenge, {
     headers: {

--- a/src/core/challenge/ChallengeApi.ts
+++ b/src/core/challenge/ChallengeApi.ts
@@ -22,6 +22,34 @@ export const getChallengesFetch = async (page: number = 1, size: number = 10): P
   return data
 }
 
+export const getActiveChallengesFetch = async (page: number = 1, size: number = 10): Promise<PageResponse<Challenge>> => {
+  const { data } = await axios.get(`${VITE_API_URL}/challenge/active`, {
+    params: {
+      page,
+      size,
+    },
+    headers: {
+      Authorization: getToken()
+    }
+  })
+  console.log('API Response:', data)  // 응답 데이터 로깅
+  return data
+}
+
+export const getEndedChallengeSchedulesFetch = async (page: number = 1, size: number = 10): Promise<PageResponse<Challenge>> => {
+  const { data } = await axios.get(`${VITE_API_URL}/challenge/end`, {
+    params: {
+      page,
+      size,
+    },
+    headers: {
+      Authorization: getToken()
+    }
+  })
+  console.log('API Response:', data)  // 응답 데이터 로깅
+  return data
+}
+
 export const getChallengeDetailFetch = async (challengeId: number): Promise<Challenge> => {
   const { data } = await axios.get(`${VITE_API_URL}/challenge/${challengeId}`, {
     params: {
@@ -63,12 +91,3 @@ export const getUserChallengeFetch = async (userId: number, page: number = 0): P
   return data
 }
 
-export const addChallengeFetch = async (challenge: Challenge): Promise<AxiosResponse<ApiResponse>> => {
-  const response = await axios.post(`${VITE_API_URL}/admin/challenge`, challenge, {
-    headers: {
-      Authorization: getToken()
-    }
-  })
-  console.log('API Response:', response)  // 응답 데이터 로깅
-  return response
-}

--- a/src/core/challenge/ChallengeType.ts
+++ b/src/core/challenge/ChallengeType.ts
@@ -8,7 +8,7 @@ export type Challenge = {
   challengeDeleteDate?: string
   challengeIsEnded?: number
   challengeCategoryName?: string
-  challengeAuthorId?: number
+  challengeAuthorId?: string
   challengeParticipantCnt?: number
   challengeTargetCnt?: number
   challengeIsParticipant?: number

--- a/src/core/challenge/composables/useGetActiveChallenges.ts
+++ b/src/core/challenge/composables/useGetActiveChallenges.ts
@@ -1,0 +1,57 @@
+import { PageResponse } from "@/core/common/types/PageType";
+import type { Challenge } from "../ChallengeType";
+import { ref } from "vue";
+import { setLoading, setError } from '../utils/settingUtils';
+import { challengeService } from "../services/challengesService";
+import { getActiveChallengesFetch } from '../ChallengeApi';
+
+export const useGetActiveChallenges = () => {
+  const loading = ref(false)
+  const error = ref('')
+  const { formatChallengeResponse, navigateToDetail, handleError } = challengeService
+  const challenges = ref<PageResponse<Challenge>>({
+    content: [],
+    pageInfo: {
+      currentPage: 0,
+      pageSize: 10,
+      totalElements: 0,
+      totalPages: 0
+    }
+  })
+
+  // 진행 중인 챌린지 목록 조회
+  const fetchActiveChallenges = async (page: number = 1, pageSize: number = 10): Promise<void> => {
+    const state = { loading, error }
+    setLoading(state, true)
+    setError(state, '')
+
+    try {
+      const response = await getActiveChallengesFetch(page, pageSize)
+      console.log(response)
+      challenges.value = formatChallengeResponse(response)
+    } catch (err: any) {
+      setError(state, handleError(err))
+      console.error('진행 중인 챌린지 목록을 불러오는데 실패했습니다:', err)
+    } finally {
+      setLoading(state, false)
+    }
+  }
+
+  // 페이지 변경
+  const changePage = async (page: number, pageSize: number): Promise<void> => {
+    await fetchActiveChallenges(page, pageSize);
+  }
+
+  const goToDetail = (challengeId: number) => {
+    navigateToDetail(challengeId);
+  }
+
+  return {
+    loading,
+    error,
+    challenges,
+    fetchActiveChallenges,
+    changePage,
+    goToDetail
+  }
+}

--- a/src/core/challenge/composables/useGetEndedChallenges.ts
+++ b/src/core/challenge/composables/useGetEndedChallenges.ts
@@ -1,0 +1,57 @@
+import { PageResponse } from "@/core/common/types/PageType";
+import type { Challenge } from "../ChallengeType";
+import { ref } from "vue";
+import { setLoading, setError } from '../utils/settingUtils';
+import { challengeService } from "../services/challengesService";
+import { getEndedChallengeSchedulesFetch } from '../ChallengeApi';
+
+export const useGetEndedChallenges = () => {
+  const loading = ref(false)
+  const error = ref('')
+  const { formatChallengeResponse, navigateToDetail, handleError } = challengeService
+  const challenges = ref<PageResponse<Challenge>>({
+    content: [],
+    pageInfo: {
+      currentPage: 0,
+      pageSize: 10,
+      totalElements: 0,
+      totalPages: 0
+    }
+  })
+
+  // 종료된 챌린지 목록 조회
+  const fetchEndedChallenges = async (page: number = 1, pageSize: number = 10): Promise<void> => {
+    const state = { loading, error }
+    setLoading(state, true)
+    setError(state, '')
+
+    try {
+      const response = await getEndedChallengeSchedulesFetch(page, pageSize)
+      console.log(response)
+      challenges.value = formatChallengeResponse(response)
+    } catch (err: any) {
+      setError(state, handleError(err))
+      console.error('종료된 챌린지 목록을 불러오는데 실패했습니다:', err)
+    } finally {
+      setLoading(state, false)
+    }
+  }
+
+  // 페이지 변경
+  const changePage = async (page: number, pageSize: number): Promise<void> => {
+    await fetchEndedChallenges(page, pageSize);
+  }
+
+  const goToDetail = (challengeId: number) => {
+    navigateToDetail(challengeId);
+  }
+
+  return {
+    loading,
+    error,
+    challenges,
+    fetchEndedChallenges,
+    changePage,
+    goToDetail
+  }
+}

--- a/src/core/challenge/utils/challengeValidation.ts
+++ b/src/core/challenge/utils/challengeValidation.ts
@@ -1,0 +1,52 @@
+import { Challenge } from "../ChallengeType"
+import { useCreateChallenge } from "../composables/useCreateChallenge"
+
+export type ChallengeErrors = {
+  challengeTitle?: string
+  challengeDescription?: string
+  challengeTargetCnt?: string
+  challengeCategoryCode?: string
+  challengeCreateDate?: string
+  challengeDeleteDate?: string
+  challengeSchedulerCycle?: string
+}
+
+export const validateChallengeForm = (form: Challenge): ChallengeErrors => {
+  const errors: ChallengeErrors = {}
+  const { isRecurring } = useCreateChallenge();
+
+  if (!form.challengeTitle?.trim()) {
+    errors.challengeTitle = '챌린지 제목을 입력해주세요.'
+  }
+
+  if (!form.challengeDescription?.trim()) {
+    errors.challengeDescription = '챌린지 설명을 입력해주세요.'
+  }
+
+  if (!form.challengeTargetCnt || form.challengeTargetCnt <= 0) {
+    errors.challengeTargetCnt = '유효한 목표 인원 수를 입력해주세요.'
+  }
+
+  if (!form.challengeCategoryCode) {
+    errors.challengeCategoryCode = '카테고리를 선택해주세요.'
+  }
+
+  if (!form.challengeCreateDate) {
+    errors.challengeCreateDate = '시작 날짜를 선택해주세요.'
+  }
+
+  if (!form.challengeDeleteDate) {
+    errors.challengeDeleteDate = '종료 날짜를 선택해주세요.'
+  }
+
+  if (isRecurring.value && !form.challengeSchedulerCycle) {
+    errors.challengeSchedulerCycle = '반복 주기를 선택해주세요.'
+  }
+
+  // 시작 날짜가 종료 날짜보다 늦은 경우
+  if (form.challengeCreateDate && form.challengeDeleteDate && new Date(form.challengeCreateDate) > new Date(form.challengeDeleteDate)) {
+    errors.challengeDeleteDate = '종료 날짜는 시작 날짜보다 늦어야 합니다.'
+  }
+
+  return errors
+}

--- a/src/views/admin/CreateChallengeView.vue
+++ b/src/views/admin/CreateChallengeView.vue
@@ -4,48 +4,21 @@ import BasicInput from '@/components/atoms/BasicInput.vue';
 import BasicRadio from '@/components/atoms/BasicRadio.vue';
 import BasicButton from '@/components/atoms/BasicButton.vue';
 import BasicSelect from '@/components/molecules/BasicSelect.vue';
-import { ref } from 'vue';
+import CreateChallengeSkeleton from '@/components/skeletons/CreateChallengeSkeleton.vue';
+import { useCreateChallenge } from '@/core/challenge/composables/useCreateChallenge'
 
-interface ChallengeForm {
-  challengeCategoryCode: string
-  challengeTitle: string
-  challengeDescription: string
-  challengeAuthorId: string
-  challengeTargetCnt: number
-  startDate: string
-  endDate: string
-  isRecurring: boolean
-  period?: number
-}
+const {
+  form,
+  isLoading,
+  isRecurring,
+  submitForm,
+  isFormValid
+} = useCreateChallenge()
 
 // 임시 카테고리 데이터
 const categoryOptions = {
-  'WALK': '걷기',
-  'RUN': '달리기',
-  'HEALTH': '헬스',
-  'YOGA': '요가',
-  'SWIMMING': '수영'
-}
-
-const form = ref<ChallengeForm>({
-  challengeCategoryCode: '',
-  challengeTitle: '',
-  challengeDescription: '',
-  challengeAuthorId: '', // 실제로는 로그인된 관리자 ID를 사용
-  challengeTargetCnt: 0,
-  startDate: '',
-  endDate: '',
-  isRecurring: false,
-  period: undefined
-})
-
-const submitForm = async () => {
-  try {
-    // API 호출 로직 구현
-    console.log('Form submitted:', form.value)
-  } catch (error) {
-    console.error('Error submitting form:', error)
-  }
+  '1': '뛰기',
+  '2': '걷기',
 }
 </script>
 
@@ -54,126 +27,133 @@ const submitForm = async () => {
     <Header title="챌린지 생성" />
 
     <div class="max-w-6xl mx-auto p-4">
-      <div class="bg-white rounded-lg shadow-sm p-6">
-        <h2 class="text-2xl font-bold mb-6 text-gray-800">챌린지 생성</h2>
+      <template v-if="isLoading">
+        <CreateChallengeSkeleton padding="large" />
+      </template>
+      <template v-else>
+        <div class="bg-white rounded-lg shadow-sm p-6">
+          <h2 class="text-2xl font-bold mb-6 text-gray-800">챌린지 생성</h2>
 
-        <form @submit.prevent="submitForm" class="space-y-6">
-          <BasicRadio
-            id="challengeType"
-            name="challengeType"
-            label="챌린지 유형"
-            v-model="form.isRecurring"
-            :options="[
-              { label: '일회성 챌린지', value: false },
-              { label: '반복 챌린지', value: true }
-            ]"
-            direction="row"
-          />
+          <form @submit.prevent="submitForm" class="space-y-6">
+            <BasicRadio
+              id="challengeType"
+              name="challengeType"
+              label="챌린지 유형"
+              v-model="isRecurring"
+              :options="[
+                { label: '일회성 챌린지', value: false },
+                { label: '반복 챌린지', value: true }
+              ]"
+              direction="row"
+            />
 
-          <BasicSelect
-            id="category"
-            label="카테고리"
-            name="category"
-            v-model="form.challengeCategoryCode"
-            :options="categoryOptions"
-            placeholder="카테고리를 선택해주세요"
-            direction="col"
-          />
+            <BasicSelect
+              id="category"
+              label="카테고리"
+              name="category"
+              v-model="form.challengeCategoryCode"
+              :options="categoryOptions"
+              placeholder="카테고리를 선택해주세요"
+              direction="col"
+            />
 
-          <BasicInput
-            id="title"
-            label="챌린지 제목"
-            name="challengeTitle"
-            v-model="form.challengeTitle"
-            direction="col"
-            required
-          />
-
-          <div class="space-y-2">
-            <label class="block text-gray-700 font-medium">챌린지 설명</label>
-            <textarea
-              v-model="form.challengeDescription"
+            <BasicInput
+              id="title"
+              label="챌린지 제목"
+              name="challengeTitle"
+              v-model="form.challengeTitle"
+              direction="col"
               required
-              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 min-h-[100px]"
-            ></textarea>
-          </div>
+            />
 
-          <BasicInput
-            id="targetCount"
-            label="목표 인원 수"
-            name="challengeTargetCnt"
-            type="number"
-            v-model="form.challengeTargetCnt"
-            direction="col"
-            required
-          />
-
-          <template v-if="form.isRecurring">
             <div class="space-y-2">
-              <label class="block text-gray-700 font-medium">반복 주기</label>
-              <select
-                v-model="form.period"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
-              >
-                <option value="1">일일</option>
-                <option value="2">일주일</option>
-                <option value="3">한달</option>
-              </select>
+              <label class="block text-gray-700 font-medium">챌린지 설명</label>
+              <textarea
+                v-model="form.challengeDescription"
+                required
+                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 min-h-[100px]"
+              ></textarea>
             </div>
 
             <BasicInput
-              id="startDate"
-              label="반복 시작 날짜"
-              name="startDate"
-              type="datetime-local"
-              v-model="form.startDate"
+              id="targetCount"
+              label="목표 인원 수"
+              name="challengeTargetCnt"
+              type="number"
+              v-model="form.challengeTargetCnt"
               direction="col"
               required
             />
 
-            <BasicInput
-              id="endDate"
-              label="반복 종료 날짜"
-              name="endDate"
-              type="datetime-local"
-              v-model="form.endDate"
-              direction="col"
-              required
-            />
-          </template>
+            <template v-if="isRecurring">
+              <div class="space-y-2">
+                <label class="block text-gray-700 font-medium">반복 주기</label>
+                <select
+                  v-model="form.challengeSchedulerCycle"
+                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+                >
+                  <option value="1">일일</option>
+                  <option value="2">일주일</option>
+                  <option value="3">한달</option>
+                </select>
+              </div>
 
-          <template v-else>
-            <BasicInput
-              id="startDate"
-              label="시작 날짜"
-              name="startDate"
-              type="datetime-local"
-              v-model="form.startDate"
-              direction="col"
-              required
-            />
+              <BasicInput
+                id="startDate"
+                label="반복 시작 날짜"
+                name="startDate"
+                type="datetime-local"
+                v-model="form.challengeCreateDate"
+                direction="col"
+                required
+              />
 
-            <BasicInput
-              id="endDate"
-              label="종료 날짜"
-              name="endDate"
-              type="datetime-local"
-              v-model="form.endDate"
-              direction="col"
-              required
-            />
-          </template>
+              <BasicInput
+                id="endDate"
+                label="반복 종료 날짜"
+                name="endDate"
+                type="datetime-local"
+                v-model="form.challengeDeleteDate"
+                direction="col"
+                required
+              />
+            </template>
 
-          <BasicButton
-            type="submit"
-            color="primary"
-            size="lg"
-            className="w-full"
-          >
-            챌린지 생성
-          </BasicButton>
-        </form>
-      </div>
+            <template v-else>
+              <BasicInput
+                id="startDate"
+                label="시작 날짜"
+                name="startDate"
+                type="datetime-local"
+                v-model="form.challengeCreateDate"
+                direction="col"
+                required
+              />
+
+              <BasicInput
+                id="endDate"
+                label="종료 날짜"
+                name="endDate"
+                type="datetime-local"
+                v-model="form.challengeDeleteDate"
+                direction="col"
+                required
+              />
+            </template>
+
+            <BasicButton
+              type="submit"
+              color="primary"
+              size="lg"
+              class="w-full"
+              :disabled="!isFormValid"
+              :loading="isLoading"
+            >
+              챌린지 생성
+            </BasicButton>
+          </form>
+        </div>
+      </template>
     </div>
   </div>
 </template>

--- a/src/views/admin/EndedChallengeView.vue
+++ b/src/views/admin/EndedChallengeView.vue
@@ -1,11 +1,76 @@
+<!-- views/admin/EndedChallengesView.vue -->
 <script setup lang="ts">
+import { useGetEndedChallenges } from '@/core/challenge/composables/useGetEndedChallenges'
+import BasicButton from '@/components/atoms/BasicButton.vue'
+import { useRouter } from 'vue-router'
+import { onMounted } from 'vue';
+
+const router = useRouter()
+const {
+  loading,
+  error,
+  challenges,
+  fetchEndedChallenges
+} = useGetEndedChallenges()
+
+// Initial fetch
+onMounted(async () => await fetchEndedChallenges())
+
+const goToDetail = (id: number) => {
+  router.push(`/admin/challenge/${id}`)
+}
 </script>
 
 <template>
-  <div class="space-y-4">
-    <div class="challenge-list">
-      <!-- 종료된 챌린지 리스트 -->
-      <h3>종료된 챌린지 목록</h3>
+  <div class="space-y-6">
+    <!-- 로딩 상태 -->
+    <div v-if="loading" class="space-y-4">
+      <div v-for="n in 3" :key="n" class="animate-pulse">
+        <div class="bg-white p-6 rounded-lg shadow-sm">
+          <div class="flex justify-between items-center">
+            <div class="space-y-3 flex-1">
+              <div class="h-4 bg-gray-200 rounded w-1/4"></div>
+              <div class="h-3 bg-gray-200 rounded w-3/4"></div>
+            </div>
+            <div class="w-20 h-6 bg-gray-200 rounded-full"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 에러 상태 -->
+    <div v-else-if="error" class="flex justify-center py-8">
+      <p class="text-red-500">{{ error }}</p>
+    </div>
+
+    <!-- 챌린지 목록 -->
+    <div v-else class="space-y-4">
+      <div v-if="challenges.content.length === 0" class="text-center py-8 text-gray-500">
+        종료된 챌린지가 없습니다.
+      </div>
+      <div
+        v-else
+        v-for="challenge in challenges.content"
+        :key="challenge.challengeId"
+        class="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+        @click="goToDetail(challenge.challengeId ?? 0)"
+      >
+        <div class="flex justify-between items-center">
+          <div class="space-y-2">
+            <h3 class="text-lg font-semibold text-gray-800">{{ challenge.challengeTitle }}</h3>
+            <p class="text-sm text-gray-600">
+              최종 참여자 {{ challenge.challengeParticipantCnt }}명 ·
+              {{ challenge.challengeCreateDate }} ~ {{ challenge.challengeDeleteDate }}
+            </p>
+          </div>
+          <BasicButton
+            color="secondary"
+            @click="goToDetail(challenge.challengeId ?? 0)"
+          >
+            결과보기
+          </BasicButton>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/src/views/admin/OngoingChallengeView.vue
+++ b/src/views/admin/OngoingChallengeView.vue
@@ -1,11 +1,76 @@
+<!-- views/admin/OngoingChallengesView.vue -->
 <script setup lang="ts">
+import { useGetActiveChallenges } from '@/core/challenge/composables/useGetActiveChallenges'
+import BasicButton from '@/components/atoms/BasicButton.vue'
+import { useRouter } from 'vue-router'
+import { onMounted } from 'vue';
+
+const router = useRouter()
+const {
+  loading,
+  error,
+  challenges,
+  fetchActiveChallenges,
+  goToDetail
+} = useGetActiveChallenges()
+
+// Initial fetch
+onMounted(async () => {
+  await fetchActiveChallenges()
+})
+
 </script>
 
 <template>
-  <div class="space-y-4">
-    <div class="challenge-list">
-      <!-- 진행중인 챌린지 리스트 -->
-      <h3>진행중인 챌린지 목록</h3>
+  <div class="space-y-6">
+    <!-- 로딩 상태 -->
+    <div v-if="loading" class="space-y-4">
+      <div v-for="n in 3" :key="n" class="animate-pulse">
+        <div class="bg-white p-6 rounded-lg shadow-sm">
+          <div class="flex justify-between items-center">
+            <div class="space-y-3 flex-1">
+              <div class="h-4 bg-gray-200 rounded w-1/4"></div>
+              <div class="h-3 bg-gray-200 rounded w-3/4"></div>
+            </div>
+            <div class="w-20 h-6 bg-gray-200 rounded-full"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 에러 상태 -->
+    <div v-else-if="error" class="flex justify-center py-8">
+      <p class="text-red-500">{{ error }}</p>
+    </div>
+
+    <!-- 챌린지 목록 -->
+    <div v-else class="space-y-4">
+      <div v-if="challenges.content.length === 0" class="text-center py-8 text-gray-500">
+        진행중인 챌린지가 없습니다.
+      </div>
+      <div
+        v-else
+        v-for="challenge in challenges.content"
+        :key="challenge.challengeId"
+        class="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+        @click="goToDetail(challenge.challengeId ?? 0)"
+      >
+        <div class="flex justify-between items-center">
+          <div class="space-y-2">
+            <h3 class="text-lg font-semibold text-gray-800">{{ challenge.challengeTitle }}</h3>
+            <p class="text-sm text-gray-600">
+              참여자 {{ challenge.challengeParticipantCnt }}명 ·
+              {{ challenge.challengeCreateDate }} ~ {{ challenge.challengeDeleteDate }}
+            </p>
+          </div>
+          <BasicButton
+            color="secondary"
+            @click="goToDetail(challenge.challengeId ?? 0)"
+          >
+            관리하기
+          </BasicButton>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/src/views/admin/ScheduleManageView.vue
+++ b/src/views/admin/ScheduleManageView.vue
@@ -1,11 +1,127 @@
+<!-- views/admin/ChallengeScheduleView.vue -->
 <script setup lang="ts">
+import { ref } from 'vue'
+import BasicButton from '@/components/atoms/BasicButton.vue'
+import { useRouter } from 'vue-router'
+
+interface Schedule {
+  id: number
+  title: string
+  frequency: string
+  nextRunDate: string
+  status: 'active' | 'paused'
+}
+
+const router = useRouter()
+const loading = ref(false)
+const error = ref('')
+const schedules = ref<Schedule[]>([])
+
+const mockSchedules: Schedule[] = [
+  {
+    id: 1,
+    title: '주간 걷기 챌린지',
+    frequency: '매주 월요일',
+    nextRunDate: '2024-01-22',
+    status: 'active'
+  },
+  {
+    id: 2,
+    title: '월간 달리기 챌린지',
+    frequency: '매월 1일',
+    nextRunDate: '2024-02-01',
+    status: 'active'
+  }
+]
+
+// 실제 API 연동 시 사용할 함수
+const fetchSchedules = async () => {
+  loading.value = true
+  error.value = ''
+
+  try {
+    // TODO: API 연동
+    schedules.value = mockSchedules
+  } catch (e) {
+    error.value = '스케줄 목록을 불러오는데 실패했습니다.'
+  } finally {
+    loading.value = false
+  }
+}
+
+const toggleScheduleStatus = async (schedule: Schedule) => {
+  try {
+    // TODO: API 연동
+    schedule.status = schedule.status === 'active' ? 'paused' : 'active'
+  } catch (e) {
+    error.value = '스케줄 상태 변경에 실패했습니다.'
+  }
+}
+
+const goToScheduleDetail = (id: number) => {
+  router.push(`/admin/schedule/${id}`)
+}
+
+// Initial fetch
+fetchSchedules()
 </script>
 
 <template>
-  <div class="space-y-4">
-    <div class="challenge-list">
-      <!-- 스케줄 관리 리스트 -->
-      <h3>스케줄 관리</h3>
+  <div class="space-y-6">
+    <!-- 로딩 상태 -->
+    <div v-if="loading" class="space-y-4">
+      <div v-for="n in 2" :key="n" class="animate-pulse">
+        <div class="bg-white p-6 rounded-lg shadow-sm">
+          <div class="flex justify-between items-center">
+            <div class="space-y-3 flex-1">
+              <div class="h-4 bg-gray-200 rounded w-1/4"></div>
+              <div class="h-3 bg-gray-200 rounded w-3/4"></div>
+            </div>
+            <div class="w-20 h-6 bg-gray-200 rounded-full"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 에러 상태 -->
+    <div v-else-if="error" class="flex justify-center py-8">
+      <p class="text-red-500">{{ error }}</p>
+    </div>
+
+    <!-- 스케줄 목록 -->
+    <div v-else class="space-y-4">
+      <div v-if="schedules.length === 0" class="text-center py-8 text-gray-500">
+        등록된 스케줄이 없습니다.
+      </div>
+      <div
+        v-else
+        v-for="schedule in schedules"
+        :key="schedule.id"
+        class="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow"
+      >
+        <div class="flex justify-between items-center">
+          <div class="space-y-2">
+            <h3 class="text-lg font-semibold text-gray-800">{{ schedule.title }}</h3>
+            <p class="text-sm text-gray-600">
+              {{ schedule.frequency }} · 다음 실행일: {{ schedule.nextRunDate }}
+            </p>
+          </div>
+          <div class="space-x-2">
+            <BasicButton
+              :color="schedule.status === 'active' ? 'warning' : 'primary'"
+              @click="toggleScheduleStatus(schedule)"
+            >
+              {{ schedule.status === 'active' ? '일시중지' : '재시작' }}
+            </BasicButton>
+            <BasicButton
+              color="secondary"
+              @click="goToScheduleDetail(schedule.id)"
+            >
+              수정하기
+            </BasicButton>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
- 진행중인 챌린지 표시, 관리하기 누르면 해당 디테일로 넘어감
- 완료된 챌린지 표시, 결과보기 누르면 해당 디테일로 넘어감

- 아직 미구현인 것 
- 1. 관리자로 로그인시 챌린지 디테일 뷰에 삭제 버튼 만들기
- 2. 유저가 챌린지 참여 취소하는 로직
- 3. 챌린지 디테일 뷰에 댓글기능 추가